### PR TITLE
fix: function name in lua and curl URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ directory as follows.
 
 ```
 curl -fLo ~/.config/nvim/lua/jetpack.lua --create-dirs \
-    https://raw.githubusercontent.com/tani/vim-jetpack/master/jetpack.lua
+    https://raw.githubusercontent.com/tani/vim-jetpack/master/lua/jetpack.lua
 ```
 
 #### packer style

--- a/lua/jetpack.lua
+++ b/lua/jetpack.lua
@@ -1,25 +1,25 @@
 function startup(config)
-  vim.fn['pack#begin']()
+  vim.fn['jetpack#begin']()
   config(function (plugin)
     if (type(plugin) == 'string') then
-      vim.fn['pack#add'](plugin)
+      vim.fn['jetpack#add'](plugin)
     else
-      vim.fn['pack#add'](plugin[1], plugin)
+      vim.fn['jetpack#add'](plugin[1], plugin)
     end
   end)
   vim.fn['pack#end']()
 end
 
 function setup(config)
-  vim.fn['pack#begin']()
+  vim.fn['jetpack#begin']()
   for _, plugin in pairs(config) do
     if (type(plugin) == 'string') then
-      vim.fn['pack#add'](plugin)
+      vim.fn['jetpack#add'](plugin)
     else
-      vim.fn['pack#add'](plugin[1], plugin)
+      vim.fn['jetpack#add'](plugin[1], plugin)
     end
   end
-  vim.fn['pack#end']()
+  vim.fn['jetpack#end']()
 end
 
 return { startup = startup }


### PR DESCRIPTION
- Function names in jetpack.lua is incorrect, so fix them.
- The URL for curl has incorrect path, so fix this.