### PR TITLE
fix: export `setup` method

### DIFF
--- a/lua/jetpack.lua
+++ b/lua/jetpack.lua
@@ -22,4 +22,7 @@ function setup(config)
   vim.fn['jetpack#end']()
 end
 
-return { startup = startup }
+return { 
+  startup = startup,
+  setup = setup
+}


### PR DESCRIPTION
seems like the `setup` method for the paq-style dsl wasn't exported