### PR TITLE
Support git URL

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -336,7 +336,7 @@ function! jetpack#add(plugin, ...) abort
   let name = get(opts, 'as', fnamemodify(a:plugin, ':t'))
   let path = get(opts, 'dir', s:srcdir . '/' . name)
   let pkg  = {
-  \  'url': 'https://github.com/' . a:plugin,
+  \  'url': a:plugin =~ ':' ? a:plugin : 'https://github.com/' . a:plugin,
   \  'branch': get(opts, 'branch', get(opts, 'tag')),
   \  'hook': get(opts, 'do'),
   \  'subdir': get(opts, 'rtp', '.'),

--- a/autoload/jetpack.win.vim
+++ b/autoload/jetpack.win.vim
@@ -337,7 +337,7 @@ function! jetpack#add(plugin, ...) abort
   let name = get(opts, 'as', fnamemodify(a:plugin, ':t'))
   let path = get(opts, 'dir', s:srcdir . '/' . name)
   let pkg  = {
-  \  'url': 'https://github.com/' . a:plugin,
+  \  'url': a:plugin =~ ':' ? a:plugin : 'https://github.com/' . a:plugin,
   \  'branch': get(opts, 'branch', get(opts, 'tag')),
   \  'hook': get(opts, 'do'),
   \  'subdir': get(opts, 'rtp', '.'),


### PR DESCRIPTION
After switching from vim-plug, I had noticed that jetpack had failed to install one of my plugin which comes from gitlab.

I think this patch should fix it.