### PR TITLE
Define dummy autocmds to suppress error messages

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -461,6 +461,8 @@ function! jetpack#end() abort
       endfor
       let event = substitute(substitute(pkg.name, '\W\+', '_', 'g'), '\(^\|_\)\(.\)', '\u\2', 'g')
       execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once doautocmd User Jetpack%s', pkg.name, event)
+      " Define a dummy autocmd to suppress "No matching autocommands" message
+      execute printf('autocmd Jetpack User Jetpack%s :', event)
     elseif isdirectory(s:path(s:optdir, pkg.name))
       execute 'silent! packadd! ' . pkg.name
     endif


### PR DESCRIPTION
On Vim, `doautocmd User JetpackSomePlug` shows error messages when no autocommand for `User JetpackSomePlug` exists, as documented in the `:help User`.
(It seems "fixed" on Neovim)

This patch suppress these messages by defining dummy autocommands as a workaround, which is also documented in the `:help User`.