### PR TITLE
add `--recursive` option to `git clone` for accepting plugins with submodules

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -181,7 +181,7 @@ function! jetpack#install(...) abort
     endif
     let cmd = ['git', 'clone']
     if !has_key(pkg, 'commit')
-      call extend(cmd, ['--depth', '1'])
+      call extend(cmd, ['--depth', '1', '--recursive'])
     endif
     if has_key(pkg, 'branch') || has_key(pkg, 'tag')
       call extend(cmd, ['-b', get(pkg, 'branch', get(pkg, 'tag'))])


### PR DESCRIPTION
Some plugins use `git submodule` to use external libraries, which are not cloned by default `git clone`.
I have confirmed that this works well with "hoschi/yode-nvim" in neovim.