### PR TITLE
Fix obtained branch name contains newline

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -254,7 +254,7 @@ function! jetpack#clean() abort
       endif
     endif
     if isdirectory(pkg.path) && (has_key(pkg, 'branch') || has_key(pkg, 'tag'))
-      let branch = system(printf('git -C "%s" rev-parse --abbrev-ref HEAD', pkg.path))
+      let branch = trim(system(printf('git -C "%s" rev-parse --abbrev-ref HEAD', pkg.path)))
       if get(pkg, 'branch', get(pkg, 'tag')) != branch
         call delete(pkg.path, 'rf')
       endif


### PR DESCRIPTION
When `branch` is specified for a plugin, jetpack always clean and re-clone that plugin on `:JetpackSync` because obtained branch name contains trailing newline.
(reproduced on Vim on Windows and WSL Ubuntu)
This patch fixes that bug.