### PR TITLE
Add SourcePre event

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -466,6 +466,7 @@ function! jetpack#end() abort
         endif
       endfor
       let event = substitute(substitute(pkg.name, '\W\+', '_', 'g'), '\(^\|_\)\(.\)', '\u\2', 'g')
+      execute printf('autocmd Jetpack SourcePre **/pack/jetpack/opt/%s/* ++once doautocmd User JetpackPre%s', pkg.name, event)    
       execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once doautocmd User Jetpack%s', pkg.name, event)
       " Define a dummy autocmd to suppress "No matching autocommands" message
       execute printf('autocmd Jetpack User Jetpack%s :', event)

--- a/doc/jetpack.txt
+++ b/doc/jetpack.txt
@@ -128,6 +128,11 @@ User Jetpack{PluginName}                                    *User-Jetpack-event*
     because Neovim does not load any files until the module is required.
     Instead, consider |User-Jetpack-event-lua|.
 
+User JetpackPre{PluginName}
+    Same as |User-Jetpack-event|.
+    Code to execute before the plugin is lazily loaded on demand with
+    `User JetpackPre{PluginName}` .
+
 User Jetpack{ModuleName}                                *User-Jetpack-event-lua*
     Let {ModuleName} be a CamelCase of module name.
         vim-jetpack --> VimJetpack


### PR DESCRIPTION
May it be useful to lazily evaluate some code before plugin loaded instead of putting them in `vimrc` or `~/.vim/plugin`