### PR TITLE
Fix regression and warn about deprecated autocommands when they are used

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -485,7 +485,7 @@ endfunction
 function! s:warn_deprecated_autocmd(event) abort
   if exists('#User#Jetpack' . a:event)
     echohl ErrorMsg
-    echomsg printf("Jetpack%s is deprecated. Please use Jetpack%sPost.", a:event, a:event)
+    echomsg printf('Jetpack%s is deprecated. Please use Jetpack%sPost.', a:event, a:event)
     echohl None
   endif
   execute printf('autocmd User Jetpack%s :', a:event)

--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -470,8 +470,9 @@ function! jetpack#end() abort
       execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%sPost', pkg.name, event)
       execute printf('autocmd Jetpack User Jetpack%sPre :', event)
       execute printf('autocmd Jetpack User Jetpack%sPost :', event)
-      " Deprecated
+      " Deprecated autocommand (show a message if used)
       execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%s', pkg.name, event)
+      execute printf('autocmd Jetpack User Jetpack%sPost ++once call s:warn_deprecated_autocmd(%s)', event, string(event))
     elseif isdirectory(s:path(s:optdir, pkg.name))
       execute 'silent! packadd! ' . pkg.name
     endif
@@ -479,6 +480,15 @@ function! jetpack#end() abort
   silent! packadd! _
   syntax enable
   filetype plugin indent on
+endfunction
+
+function! s:warn_deprecated_autocmd(event) abort
+  if exists('#User#Jetpack' . a:event)
+    echohl ErrorMsg
+    echomsg printf("Jetpack%s is deprecated. Please use Jetpack%sPost.", a:event, a:event)
+    echohl None
+  endif
+  execute printf('autocmd User Jetpack%s :', a:event)
 endfunction
 
 function! jetpack#tap(name) abort

--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -466,12 +466,12 @@ function! jetpack#end() abort
         endif
       endfor
       let event = substitute(substitute(pkg.name, '\W\+', '_', 'g'), '\(^\|_\)\(.\)', '\u\2', 'g')
-      execute printf('autocmd Jetpack SourcePre **/pack/jetpack/opt/%s/* doautocmd User Jetpack%sPre', pkg.name, event)
-      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%sPost', pkg.name, event)
+      execute printf('autocmd Jetpack SourcePre **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%sPre', pkg.name, event)
+      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%sPost', pkg.name, event)
       execute printf('autocmd Jetpack User Jetpack%sPre :', event)
       execute printf('autocmd Jetpack User Jetpack%sPost :', event)
       " Deprecated autocommand (show a message if used)
-      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%s', pkg.name, event)
+      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%s', pkg.name, event)
       execute printf('autocmd Jetpack User Jetpack%sPost ++once call s:warn_deprecated_autocmd(%s)', event, string(event))
     elseif isdirectory(s:path(s:optdir, pkg.name))
       execute 'silent! packadd! ' . pkg.name


### PR DESCRIPTION
Regression around the "No matching autocommand" message occured at ba7b0f3 and 6feb403.
Instead of just suppressing the error message again, I've implemented the ideal behavior that will warn about deprecated autocommands only when they are used.

By the way, it seems that `Jetpack*` autocommands are called multiple times because `++once` is missing for internal autocommands that call `Jetpack*` autocommands.
Is this the intended behavior? I think the next patch should be also applied (after merging this PR).

```diff
diff --git a/autoload/jetpack.vim b/autoload/jetpack.vim
index 4e42c73..8a335e0 100644
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -466,13 +466,13 @@ function! jetpack#end() abort
         endif
       endfor
       let event = substitute(substitute(pkg.name, '\W\+', '_', 'g'), '\(^\|_\)\(.\)', '\u\2', 'g')
-      execute printf('autocmd Jetpack SourcePre **/pack/jetpack/opt/%s/* doautocmd User Jetpack%sPre', pkg.name, event)
-      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%sPost', pkg.name, event)
+      execute printf('autocmd Jetpack SourcePre **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%sPre', pkg.name, event)
+      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%sPost', pkg.name, event)
       execute printf('autocmd Jetpack User Jetpack%sPre :', event)
       execute printf('autocmd Jetpack User Jetpack%sPost :', event)
       " Deprecated autocommand (show a message if used)
-      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* doautocmd User Jetpack%s', pkg.name, event)
-      execute printf('autocmd Jetpack User Jetpack%sPost ++once call s:warn_deprecated_autocmd(%s)', event, string(event))
+      execute printf('autocmd Jetpack SourcePost **/pack/jetpack/opt/%s/* ++once ++nested doautocmd User Jetpack%s', pkg.name, event)
+      execute printf('autocmd Jetpack User Jetpack%sPost call s:warn_deprecated_autocmd(%s)', event, string(event))
     elseif isdirectory(s:path(s:optdir, pkg.name))
       execute 'silent! packadd! ' . pkg.name
     endif
```