### PR TITLE
Use map instead of array in checking merged_files

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -269,24 +269,25 @@ function! jetpack#bundle() abort
 
   call delete(s:optdir, 'rf')
   let destdir = s:path(s:optdir, '_')
+
   " Merge plugins if possible.
   let merged_count = 0
-  let merged_files = []
+  let merged_files = {}
   for i in range(len(bundle))
     let pkg = bundle[i]
     call s:setbufline(1, printf('Merging Plugins (%d / %d)', merged_count, len(s:packages)))
     call s:setbufline(2, s:progressbar(1.0 * merged_count / len(s:packages) * 100))
     let srcdir = s:path(pkg.path, get(pkg, 'rtp', ''))
-    let srcfiles = filter(s:files(srcdir), '!s:ignorable(s:substitute(v:val, srcdir, ""))')
-    let destfiles = map(copy(srcfiles), 's:substitute(v:val, srcdir, destdir)')
     if g:jetpack#optimization == 1
-      if filter(copy(destfiles), 'index(merged_files, v:val) >= 0') != []
+      let files = map(s:files(srcdir), 's:substitute(v:val, srcdir, "")')
+      let files = filter(copy(files), '!s:ignorable(v:val)')
+      if filter(copy(files), 'has_key(merged_files, v:val)') != []
         call add(unbundle, pkg)
         continue
       endif
+      call map(copy(files), 'extend(merged_files, { v:val: v:true })')
     endif
     call s:copy(srcdir, destdir)
-    call extend(merged_files, destfiles)
     call s:setbufline(merged_count+3, printf('Merged %s ...', pkg.name))
     let merged_count += 1
   endfor

--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -281,12 +281,14 @@ function! jetpack#bundle() abort
     if g:jetpack#optimization == 1
       let files = map(s:files(srcdir), 's:substitute(v:val, srcdir, "")')
       let files = filter(files, '!s:ignorable(v:val)')
-      for file_index in range(len(files))
-        if has_key(merged_files, files[file_index])
+      let should_unbundle = v:false
+      for i in range(len(files))
+        if has_key(merged_files, files[i])
+          let should_unbundle = v:true
           break
         endif
       endfor
-      if file_index < len(files) - 1
+      if should_unbundle
         call add(unbundle, pkg)
         continue
       endif

--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -280,12 +280,17 @@ function! jetpack#bundle() abort
     let srcdir = s:path(pkg.path, get(pkg, 'rtp', ''))
     if g:jetpack#optimization == 1
       let files = map(s:files(srcdir), 's:substitute(v:val, srcdir, "")')
-      let files = filter(copy(files), '!s:ignorable(v:val)')
-      if filter(copy(files), 'has_key(merged_files, v:val)') != []
+      let files = filter(files, '!s:ignorable(v:val)')
+      for file_index in range(len(files))
+        if has_key(merged_files, files[file_index])
+          break
+        endif
+      endfor
+      if file_index < len(files) - 1
         call add(unbundle, pkg)
         continue
       endif
-      call map(copy(files), 'extend(merged_files, { v:val: v:true })')
+      call map(files, 'extend(merged_files, { v:val: v:true })')
     endif
     call s:copy(srcdir, destdir)
     call s:setbufline(merged_count+3, printf('Merged %s ...', pkg.name))


### PR DESCRIPTION
This PR aims to improve the merging performance.

I think the `if filter(copy(destfiles), 'index(merged_files, v:val) >= 0') != []` is very slow.