### PR TITLE
Fix rtp order

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -409,6 +409,7 @@ function! jetpack#begin(...) abort
   if a:0 != 0
     let s:home = expand(a:1)
     execute 'set packpath^=' . s:home
+    execute 'set runtimepath^=' . s:home
   endif
   let s:optdir = s:path(s:home, 'pack', 'jetpack', 'opt')
   let s:srcdir = s:path(s:home, 'pack', 'jetpack', 'src')


### PR DESCRIPTION
plugin syntax files did not work with neovim installed with nix package manager . 

## References
- https://github.com/neovim/neovim/issues/9390
- https://github.com/NixOS/nixpkgs/issues/39364#issuecomment-425536054
- https://github.com/NixOS/nixpkgs/pull/78385