### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ to retrieve a list of plugin names and check the availability.
 
 ```vim
 for name in jetpack#names()
-  if jetpack#tap(name)
+  if !jetpack#tap(name)
     call jetpack#sync()
     break
   endif


### PR DESCRIPTION
This PR fixes wrong the example code at [README](https://github.com/tani/vim-jetpack#is-it-possible-to-install-plugins-if-they-are-not-installed).