### PR TITLE
 Create dummy command so that users can use command completion before loading plugins

### DIFF
--- a/autoload/jetpack.vim
+++ b/autoload/jetpack.vim
@@ -463,6 +463,19 @@ function! s:lod_map(map, name, with_prefix, prefix)
   call feedkeys(substitute(a:map, '^<Plug>', "\<Plug>", 'i') . extra)
 endfunction
 
+function! s:lod_cmd(cmd, name, ...)
+  execute printf('delc %s', a:cmd)
+  execute printf('packadd %s', a:name)
+  let args = a:0>0 ? join(a:000, ' ') : ''
+  try
+    execute printf('%s %s', a:cmd, args)
+  catch /.*/
+    echohl ErrorMsg
+    echomsg v:exception
+    echohl None
+  endtry
+endfunction
+
 function! jetpack#end() abort
   delcommand Jetpack
   command! -bar JetpackSync call jetpack#sync()
@@ -491,7 +504,7 @@ function! jetpack#end() abort
           execute printf('autocmd Jetpack %s ++once ++nested silent! packadd %s', it, pkg_name)
         else
           let cmd = substitute(it, '^:', '', '')
-          execute printf('autocmd Jetpack CmdUndefined %s ++once ++nested silent! packadd %s', cmd, pkg_name)
+          execute printf('command! -nargs=* %s :call <SID>lod_cmd(%s, %s, <f-args>)', cmd, string(cmd), string(pkg_name))
         endif
       endfor
       let event = substitute(substitute(pkg_name, '\W\+', '_', 'g'), '\(^\|_\)\(.\)', '\u\2', 'g')
@@ -519,5 +532,6 @@ endfunction
 function! jetpack#get(name) abort
   return get(s:packages, a:name, {})
 endfunction
+
 
 

--- a/test/test.vim
+++ b/test/test.vim
@@ -123,10 +123,12 @@ function s:suite.on_option_cmd()
  call s:assert.isdirectory(s:optdir . '/vim-abolish')
  call s:assert.filereadable(s:optdir . '/vim-abolish/plugin/abolish.vim')
  call s:assert.notfilereadable(s:optdir . '/_/plugin/abolish.vim')
- call s:assert.cmd_not_exists('Abolish')
+ call s:assert.cmd_exists('Abolish')
+ call s:assert.cmd_not_exists('Subvert')
  call s:assert.false(s:loaded_abolish_vim)
  silent! Abolish
  call s:assert.cmd_exists('Abolish')
+ call s:assert.cmd_exists('Subvert')
  call s:assert.true(s:loaded_abolish_vim)
 endfunction
 


### PR DESCRIPTION
This patch allows users to easily access the commands for lazy loading using completion.