### PR TITLE
fix: auto install file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ vim-jetpack contains all optoins of vim-plug.
 ### Install vim-jetpack if it is unavailable.
 
 ```vim
-let s:jetpackfile = expand('<sfile>:p:h') .. 'pack/jetpack/opt/vim-jetpack/plugin/jetpack.vim'
+let s:jetpackfile = expand('<sfile>:p:h') .. '/pack/jetpack/opt/vim-jetpack/plugin/jetpack.vim'
 let s:jetpackurl = "https://raw.githubusercontent.com/tani/vim-jetpack/master/plugin/jetpack.vim"
 if !filereadable(s:jetpackfile)
   call system(printf('curl -fsSLo %s --create-dirs %s', s:jetpackfile, s:jetpackurl))


### PR DESCRIPTION
Auto Installation code on README.md may creat strange folder like "vimpack", "nvimpack".