### PR TITLE
Fix timing of setup and config being called at startup

### DIFF
--- a/test/git_test.vim
+++ b/test/git_test.vim
@@ -335,3 +335,11 @@ EOL
   call s:assert.equals(v:true, jetpack#load('vim-searchx'))
   call s:assert.equals(g:searchx.auto_accept, v:true) " Default is v:false, so if v:true, setup has been called.
 endfunction
+
+function s:suite.load_timing()
+  lua <<EOL
+  packer_setup({
+    'hrsh7th/cmp-buffer',
+  })
+EOL
+endfunction


### PR DESCRIPTION
これで全ての非遅延読み込みのプラグインに対して、
- 各プラグインのpackaddより先にsetupが呼ばれる
- 全てのpackaddが終わってからconfig群は呼ばれる

ようになるはずです。主にnvim-cmp周りの依存関係が壊れまくったので必要なんですがテストどう書こうか。。。