### PR TITLE
Add silent to bwipeout

### DIFF
--- a/plugin/jetpack.vim
+++ b/plugin/jetpack.vim
@@ -36,7 +36,7 @@ elseif has('patch-8.2.4594')
     execute 'silent buffer' t
     call setline(1, split(a:code, "\n"))
     source
-    execute 'bwipeout!' t
+    execute 'silent bwipeout!' t
     execute 'silent buffer' c
   endfunction
 else


### PR DESCRIPTION
fix #107

Add `silent` to `bwipeout` to avoid showing filename when startup vim.