### PR TITLE
fix falsy value returned from boolean function in lua

### DIFF
--- a/plugin/jetpack.vim
+++ b/plugin/jetpack.vim
@@ -882,7 +882,13 @@ local Jetpack = {}
 for _, name in pairs({'begin', 'end', 'add', 'names', 'get', 'tap', 'sync', 'load'}) do
   Jetpack[name] = function(...)
     local result = vim.fn['jetpack#' .. name](...)
-    return result == 0 and false or result == 1 and true or result
+    if result == 0 then
+      return false
+    elseif result == 1 then
+      return true
+    else
+      return result
+    end
   end
 end
 Jetpack.prologue = Jetpack['begin']


### PR DESCRIPTION
### Problem
In lua code, `jetpack.tap` returns `0`, which is a truthy value in lua, when the specified plugin is not available. If the plugin is available, `jetpack.tap` returns `true`, not `1`.

### Cause
In line 885, `result == 0 and false` does not return `false` but instead it is evaluated as false, then the line eventually returns the `result`.

### Fix
Use standard if expression.