### PR TITLE
Fix current directory's Git status is hard reset in the clean_plugins function.

### DIFF
--- a/plugin/jetpack.vim
+++ b/plugin/jetpack.vim
@@ -228,8 +228,10 @@ function! s:clean_plugins() abort
   endif
   for [pkg_name, pkg] in items(s:declared_packages)
     if isdirectory(pkg.path)
-      call system(printf('git -C %s reset --hard', pkg.path)) 
-      let branch = trim(system(printf('git -C %s rev-parse --abbrev-ref %s', pkg.path, pkg.commit)))
+      if system(printf('git -C %s/.git rev-parse --is-inside-git-dir', pkg.path)) == 'true'
+        call system(printf('git -C %s reset --hard', pkg.path))
+        let branch = trim(system(printf('git -C %s rev-parse --abbrev-ref %s', pkg.path, pkg.commit)))
+      end 
       if v:shell_error && !empty(pkg.commit)
         call delete(pkg.path, 'rf')
         continue


### PR DESCRIPTION
Thank you for the easy-to-use plugin manager!
I'm glad that I can use my own previous settings.

I followed the README to set it up, but encountered a problem when I ran the first JetpackSync command, which resulted in a hard reset of the git status in the current directory.
My editing history of dotfiles is all gone :)

Upon investigation, it seems that when running *'git -C <path> command'*, if the path is not managed by git, the command is executed in the current directory.  [link](https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt)
When I installed the first jetpack.vim using the simple startup procedure with curl for this plugin, the directory was not managed by git, which seems to be the cause of this problem.

Therefore, I added an if statement to check whether the directory specified in the git reset in the clean_plugins function is managed by git or not.