### PR TITLE
Install plugins into the first directory in `packpath`

### DIFF
--- a/plugin/jetpack.vim
+++ b/plugin/jetpack.vim
@@ -520,7 +520,7 @@ function! jetpack#begin(...) abort
   elseif has('win32')
     let s:home = expand('~/vimfiles')
   else
-    let s:home = expand('~/.vim')
+    let s:home = split(&packpath, ',')[0]
   endif
   let s:cmds = {}
   let s:maps = {}


### PR DESCRIPTION
To install to the place wherever you specify in `.vimrc`.
For my use case, I add `set packpath^=$XDG_DATA_HOME/vim` to my vimrc to use `~/.local/share` (XDG Base Directory Specification), not `~/.vim`.
Even if you don't specify `packpath`, it probably already has `~/.vim` as default.

Please share your opinions. I'm not a pro on Vim Script or Vim environment.