### PR TITLE
FIX: plugin declaration can be overwitten.

### DIFF
--- a/plugin/jetpack.vim
+++ b/plugin/jetpack.vim
@@ -444,7 +444,7 @@ function! jetpack#is_opt(pkg) abort
        \ || !empty(a:pkg.cmd)
        \ || !empty(a:pkg.keys)
        \ || !empty(a:pkg.event)
-  endfunction
+endfunction
 
 function! jetpack#gets(pkg, keys, default) abort
   let values = []
@@ -461,15 +461,15 @@ function! jetpack#gets(pkg, keys, default) abort
 endfunction
 
 function! jetpack#add(plugin, ...) abort
-  if has_key(s:declared_packages, a:plugin)
+  let opts = a:0 > 0 ? a:1 : {}
+  let name = jetpack#gets(opts, ['as', 'name'], [fnamemodify(a:plugin, ':t')])[0]
+  if has_key(s:declared_packages, name)
     return
   endif
-  let opts = a:0 > 0 ? a:1 : {}
   let local = jetpack#is_local_plug(a:plugin)
   let url = local ? expand(a:plugin) : (a:plugin !~# '.\+://' ? 'https://github.com/' : '') . a:plugin
   let path = s:optdir . '/' .  substitute(url, '.\+/\(.\+\)', '\1', '')
   let path = expand(local ? a:plugin : jetpack#gets(opts, ['dir', 'path'], [path])[0])
-  let name = jetpack#gets(opts, ['as', 'name'], [fnamemodify(a:plugin, ':t')])[0]
   let dependees = jetpack#gets(opts, ['requires', 'depends'], [])
   call map(dependees, { _, r -> r =~# '/' ? substitute(r, '.*/', '', '') : r })
   let dependers_before = jetpack#gets(opts, ['before', 'on_source'], [])


### PR DESCRIPTION
**Problems**

When `jetpack#add` is called with same name's plugin, it checks against `a:plugin` that may inclues GitHub user name such as `tani/jetpack`, but key for `s:declared_packages` is plugin name such as `jetpack`, which is inconsistent.

Due to this issue, when the Lua API is used with `requires`, for example, it calls same plugin name to `use(req)` call at line around 853, which may override already declared plugin.

**Solution**

Use plugin name always for `s:declared_packages`.
This patch also includes minor indent fix.